### PR TITLE
feat: auto-apply cooldown in adrenaline phase

### DIFF
--- a/packages/backend/src/engine/game-engine.test.ts
+++ b/packages/backend/src/engine/game-engine.test.ts
@@ -24,7 +24,6 @@ function completeResolutionPhase(game: Game): void {
 			game.dispatch(playerId, {
 				type: "adrenaline",
 				acceptMove: false,
-				acceptCooldown: false,
 			});
 		}
 		game.dispatch(playerId, { type: "react", action: "skip" });
@@ -282,7 +281,6 @@ describe("Game", () => {
 				game.dispatch(PLAYER_1.id, {
 					type: "adrenaline",
 					acceptMove: false,
-					acceptCooldown: false,
 				});
 				game.dispatch(PLAYER_1.id, { type: "react", action: "skip" });
 				// Slipstream is skipped (single player has no one to slipstream)
@@ -466,12 +464,10 @@ describe("Game", () => {
 			game.dispatch(PLAYER_1.id, {
 				type: "adrenaline",
 				acceptMove: true,
-				acceptCooldown: false,
 			});
 
 			expect(game.state.players[PLAYER_1.id].turnActions.adrenaline).toEqual({
 				acceptMove: true,
-				acceptCooldown: false,
 			});
 		});
 
@@ -486,7 +482,6 @@ describe("Game", () => {
 			game.dispatch(PLAYER_1.id, {
 				type: "adrenaline",
 				acceptMove: false,
-				acceptCooldown: false,
 			});
 			game.dispatch(PLAYER_1.id, { type: "react", action: "skip" });
 
@@ -506,7 +501,6 @@ describe("Game", () => {
 			game.dispatch(PLAYER_1.id, {
 				type: "adrenaline",
 				acceptMove: false,
-				acceptCooldown: false,
 			});
 			game.dispatch(PLAYER_1.id, { type: "react", action: "boost" });
 
@@ -540,7 +534,6 @@ describe("Game", () => {
 			game.dispatch(PLAYER_2.id, {
 				type: "adrenaline",
 				acceptMove: false,
-				acceptCooldown: false,
 			});
 			game.dispatch(PLAYER_2.id, { type: "react", action: "skip" });
 			game.dispatch(PLAYER_2.id, { type: "slipstream", use: true });
@@ -583,7 +576,6 @@ describe("Game", () => {
 			game.dispatch(PLAYER_1.id, {
 				type: "adrenaline",
 				acceptMove: true,
-				acceptCooldown: false,
 			});
 			game.dispatch(PLAYER_1.id, { type: "react", action: "skip" });
 			game.dispatch(PLAYER_1.id, { type: "discard", cardIndices: [] });
@@ -714,7 +706,6 @@ describe("Game", () => {
 			game.dispatch(PLAYER_2.id, {
 				type: "adrenaline",
 				acceptMove: false,
-				acceptCooldown: false,
 			});
 			// P2 can slipstream because P1 is at same position
 			game.dispatch(PLAYER_2.id, { type: "react", action: "skip" });
@@ -761,7 +752,6 @@ describe("Game", () => {
 			game.dispatch(PLAYER_2.id, {
 				type: "adrenaline",
 				acceptMove: false,
-				acceptCooldown: false,
 			});
 			game.dispatch(PLAYER_2.id, { type: "react", action: "skip" });
 			expect(game.state.currentState).toBe("slipstream");
@@ -805,7 +795,6 @@ describe("Game", () => {
 			game.dispatch(PLAYER_2.id, {
 				type: "adrenaline",
 				acceptMove: false,
-				acceptCooldown: false,
 			});
 			game.dispatch(PLAYER_2.id, { type: "react", action: "skip" });
 

--- a/packages/backend/src/engine/game-engine.test.ts
+++ b/packages/backend/src/engine/game-engine.test.ts
@@ -471,6 +471,45 @@ describe("Game", () => {
 			});
 		});
 
+		it("should auto-apply cooldown when declining adrenaline move", () => {
+			const game = new Game(
+				{ players: [PLAYER_1, PLAYER_2], map: "USA" },
+				{ shuffle: noShuffle },
+			);
+
+			// P1 moves 0, P2 moves more to give P1 adrenaline next turn
+			game.dispatch(PLAYER_1.id, { type: "plan", gear: 1, cardIndices: [5] });
+			game.dispatch(PLAYER_2.id, {
+				type: "plan",
+				gear: 2,
+				cardIndices: [6, 4],
+			});
+			completeResolutionPhase(game);
+
+			// Turn 2: P1 has adrenaline
+			expect(game.state.players[PLAYER_1.id].hasAdrenaline).toBe(true);
+			game.dispatch(PLAYER_1.id, { type: "plan", gear: 1, cardIndices: [4] });
+			game.dispatch(PLAYER_2.id, { type: "plan", gear: 1, cardIndices: [3] });
+
+			// P2 resolves first (leader)
+			game.dispatch(PLAYER_2.id, { type: "move" });
+			game.dispatch(PLAYER_2.id, { type: "react", action: "skip" });
+			game.dispatch(PLAYER_2.id, { type: "discard", cardIndices: [] });
+
+			// P1 resolves - decline +1 move but should still get cooldown
+			game.dispatch(PLAYER_1.id, { type: "move" });
+			// P1 in gear 1 gets 3 cooldowns from beginResolution
+			expect(game.state.players[PLAYER_1.id].availableCooldowns).toBe(3);
+
+			game.dispatch(PLAYER_1.id, {
+				type: "adrenaline",
+				acceptMove: false,
+			});
+
+			// Cooldown should be auto-applied even when declining move (+1 from adrenaline)
+			expect(game.state.players[PLAYER_1.id].availableCooldowns).toBe(4);
+		});
+
 		it("should record react choice in turnActions", () => {
 			const game = new Game(
 				{ players: [PLAYER_1], map: "USA" },

--- a/packages/backend/src/engine/game.ts
+++ b/packages/backend/src/engine/game.ts
@@ -217,7 +217,7 @@ export class Game {
 				break;
 			}
 			case "adrenaline": {
-				player.applyAdrenaline(action.acceptMove, action.acceptCooldown);
+				player.applyAdrenaline(action.acceptMove);
 				this.enterReactOrSkip(playerId, player);
 				break;
 			}

--- a/packages/backend/src/engine/player.ts
+++ b/packages/backend/src/engine/player.ts
@@ -378,17 +378,15 @@ export class Player {
 		);
 	}
 
-	applyAdrenaline(acceptMove: boolean, acceptCooldown: boolean): void {
-		this._turnActions.adrenaline = { acceptMove, acceptCooldown };
+	applyAdrenaline(acceptMove: boolean): void {
+		this._turnActions.adrenaline = { acceptMove };
 		if (!this._hasAdrenaline) {
 			return;
 		}
 		if (acceptMove) {
 			this.addAdrenalineMove();
 		}
-		if (acceptCooldown) {
-			this.addCooldown(1);
-		}
+		this.addCooldown(1);
 	}
 
 	recordSlipstream(used: boolean): void {

--- a/packages/frontend/src/components/ActionPanel.tsx
+++ b/packages/frontend/src/components/ActionPanel.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import type { Action, Card as CardType, Corner, Gear, TurnState } from "@overdrive/shared";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 import { GearSelector } from "./GearSelector";
 import { Hand } from "./Hand";
 import { PlayedCards } from "./PlayedCards";
@@ -36,8 +35,6 @@ export function ActionPanel({
 }: ActionPanelProps) {
 	const [selectedGear, setSelectedGear] = useState<Gear>(currentGear);
 	const [selectedCards, setSelectedCards] = useState<number[]>([]);
-	const [adrenalineMove, setAdrenalineMove] = useState(false);
-	const [adrenalineCooldown, setAdrenalineCooldown] = useState(false);
 
 	const getNextCorner = (): { distance: number; speedLimit: number } | null => {
 		const posInTrack = ((position % trackLength) + trackLength) % trackLength;
@@ -157,52 +154,29 @@ export function ActionPanel({
 	}
 
 	if (currentState === "adrenaline") {
-		const handleAdrenalineConfirm = () => {
-			onAction({
-				type: "adrenaline",
-				acceptMove: adrenalineMove,
-				acceptCooldown: adrenalineCooldown,
-			});
-			setAdrenalineMove(false);
-			setAdrenalineCooldown(false);
-		};
-
 		return (
 			<Card>
 				<CardHeader>
 					<CardTitle>Adrenaline</CardTitle>
 				</CardHeader>
 				<CardContent className="space-y-4">
-					<p className="text-white">You have adrenaline! Select your bonus(es):</p>
+					<p className="text-white">You have adrenaline! Take +1 move?</p>
 					<div className="grid grid-cols-2 gap-2">
 						<Button
-							className={cn(
-								"bg-slate-700 text-white hover:bg-slate-600",
-								adrenalineMove && "ring-2 ring-blue-500 bg-blue-500",
-							)}
-							onClick={() => setAdrenalineMove(!adrenalineMove)}
+							className="bg-blue-600 text-white hover:bg-blue-500"
+							onClick={() => onAction({ type: "adrenaline", acceptMove: true })}
 							disabled={disabled}
 						>
 							+1 Move
 						</Button>
 						<Button
-							className={cn(
-								"bg-slate-700 text-white hover:bg-slate-600",
-								adrenalineCooldown && "ring-2 ring-blue-500 bg-blue-500",
-							)}
-							onClick={() => setAdrenalineCooldown(!adrenalineCooldown)}
+							className="bg-slate-700 text-white hover:bg-slate-600"
+							onClick={() => onAction({ type: "adrenaline", acceptMove: false })}
 							disabled={disabled}
 						>
-							Cooldown
+							Skip
 						</Button>
 					</div>
-					<Button
-						onClick={handleAdrenalineConfirm}
-						disabled={disabled}
-						className="w-full text-white hover:text-blue-500"
-					>
-						{adrenalineMove || adrenalineCooldown ? "Confirm" : "Skip"}
-					</Button>
 				</CardContent>
 			</Card>
 		);

--- a/packages/shared/src/game.ts
+++ b/packages/shared/src/game.ts
@@ -37,7 +37,7 @@ export type TurnState =
 export type ReactChoice = "cooldown" | "boost" | "skip";
 
 export interface TurnActions {
-	adrenaline?: { acceptMove: boolean; acceptCooldown: boolean };
+	adrenaline?: { acceptMove: boolean };
 	react?: { action: ReactChoice; amount?: number };
 	slipstream?: { used: boolean };
 	discard?: { count: number };
@@ -46,7 +46,7 @@ export interface TurnActions {
 export type Action =
 	| { type: "plan"; gear: Gear; cardIndices: number[] }
 	| { type: "move" }
-	| { type: "adrenaline"; acceptMove: boolean; acceptCooldown: boolean }
+	| { type: "adrenaline"; acceptMove: boolean }
 	| { type: "react"; action: ReactChoice; amount?: number }
 	| { type: "slipstream"; use: boolean }
 	| { type: "discard"; cardIndices: number[] };


### PR DESCRIPTION
## Summary

- Cooldown is now automatically applied when a player has adrenaline (no user choice needed)
- Simplified the adrenaline UI from toggle buttons + confirm to two direct action buttons: "+1 Move" and "Skip"
- Removed `acceptCooldown` parameter from the adrenaline action type

## Changes

- **Shared types**: Removed `acceptCooldown` from `TurnActions` interface and `Action` type
- **Backend**: `Player.applyAdrenaline()` now always calls `addCooldown(1)` when player has adrenaline
- **Frontend**: Replaced toggle-based UI with two direct action buttons
- **Tests**: Updated existing tests and added new test for auto-cooldown behavior

## Test plan

- [x] All 140 unit tests pass
- [x] Manual testing confirms adrenaline flow works correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UX Improvements**
  * Streamlined adrenaline interaction: cooldowns now apply automatically when adrenaline is used, eliminating the separate cooldown confirmation step. Players now make a single choice to accept or decline the move bonus.

* **Bug Fixes**
  * Fixed automatic cooldown application to trigger correctly when adrenaline moves are declined.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->